### PR TITLE
Address serialization issues with scriptclass objects

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,15 @@
 
 ## To-do items -- prioritized
 
+* Remove extraneous variables from scriptblock snapshot:
+  args                        NoteProperty   Object[] args=System.Object[]
+  MyInvocation                NoteProperty   InvocationInfo MyInvocation=System.Management.Automation.Invoca...
+  PSBoundParameters           NoteProperty   PSBoundParametersDictionary PSBoundParameters=System.Management...
+  PSCommandPath               NoteProperty   string PSCommandPath=C:\Users\adamed\src\poshgraph\.devmodule\s...
+  PSScriptRoot                NoteProperty   string PSScriptRoot=C:\Users\adamed\src\poshgraph\.devmodule\sc...
+  snapshot2                   NoteProperty   Object[] snapshot2=System.Object[]
+  varsnapshot1                Note
 * Remove superfluous verbose output from export-module
 * Remove some usage of script scope variables
 * Fix issue with test-scriptobject and psremoting jobs from start-job
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,7 @@
+# ROADMAP for ScriptClass
+
+## To-do items -- prioritized
+
+* Remove superfluous verbose output from export-module
+* Remove some usage of script scope variables
+* Fix issue with test-scriptobject and psremoting jobs from start-job

--- a/ScriptClass.psd1
+++ b/ScriptClass.psd1
@@ -17,7 +17,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.13.1'
+ModuleVersion = '0.13.5'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/ScriptClass.psd1
+++ b/ScriptClass.psd1
@@ -17,7 +17,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.13.5'
+ModuleVersion = '0.13.6'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/ScriptClass.psd1
+++ b/ScriptClass.psd1
@@ -17,7 +17,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.12.10'
+ModuleVersion = '0.13.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/include.ps1
+++ b/src/include.ps1
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-$script:includes = @{}
-$script:included = @{}
+$includes = @{}
+$included = @{}
 
-function script:CallerScriptRoot {
+function CallerScriptRoot {
     $callstack = get-pscallstack
     $caller = $null
     $thisScript = $callstack[0].scriptname
@@ -65,9 +65,9 @@ function import-script
     $relativeNormal = $relativePath.ToLower()
     $fullPath = (join-path ($appRoot) $relativePath | get-item).Fullname
     $canonical = $fullPath.ToLower()
-    if ( $script:included[$canonical] -eq $null ) {
-        $script:included[$canonical] = @(($appRoot), $relativeNormal)
-        $script:includes[$canonical] = $false
+    if ( $included[$canonical] -eq $null ) {
+        $included[$canonical] = @(($appRoot), $relativeNormal)
+        $includes[$canonical] = $false
         $canonical
     } else {
         {}

--- a/src/scriptclass.ps1
+++ b/src/scriptclass.ps1
@@ -610,6 +610,16 @@ function __get-classproperties($memberData) {
     $classProperties
 }
 
+$__staticBlockLocalVariablesToRemove = @(
+    'varsnapshot1',
+    'PSScriptRoot',
+    'snapshot2'
+    'MyInvocation',
+    'PSBoundParameters',
+    'PSCommandPath'
+    'args'
+)
+
 function static([ScriptBlock] $staticBlock) {
     function static { throw "The 'static' function may not be used from within a static block" }
     $snapshot1 = ls function:
@@ -646,6 +656,15 @@ function static([ScriptBlock] $staticBlock) {
     $varDelta.getenumerator() | foreach {
         $staticvars = $script:__staticvars__
         $staticvars[$_.name] = $_.value
+    }
+
+    # Some variables in this script are being captured -- remove them
+    $script:__staticBlockLocalVariablesToRemove | foreach {
+        if ( ! $staticvars[$_] ) {
+            throw "local variable to remove '$_' does not exist"
+        }
+
+        $staticvars.remove($_)
     }
 }
 

--- a/src/scriptclass.tests.ps1
+++ b/src/scriptclass.tests.ps1
@@ -142,9 +142,9 @@ Describe "The class definition interface" {
             $newInstance.scriptclass.scriptclass | Should BeExactly $null
         }
 
-        It "has a 'scriptclass' member that has exactly five noteproperty properties and one scriptproperty property" {
+        It "has a 'scriptclass' member that has exactly four noteproperty properties and one scriptproperty property" {
             $newInstance = new-scriptobject ClassClass53
-            ($newInstance.scriptclass | gm -membertype noteproperty).count | Should BeExactly 5
+            ($newInstance.scriptclass | gm -membertype noteproperty).count | Should BeExactly 4
             ($newInstance.scriptclass | gm -membertype scriptproperty) -is [Microsoft.PowerShell.Commands.MemberDefinition] | Should BeExactly $true
         }
 
@@ -1408,6 +1408,66 @@ Describe "The const cmdlet" {
         }
 
     }
-}
 
+    Context "When a ScriptClass instance is deserialized" {
+            It "Throws an exception when a ScriptClass  method of a deserialized class is invoked with . notation" {
+            ScriptClass DeserializedFailure {
+                function TestMethod {
+                }
+            }
+
+            $newInstance = new-so DeserializedFailure
+            { $newInstance |=> TestMethod } | Should Not Throw
+            { $newInstance.TestMethod() } | Should Not Throw
+            $job = start-job { param($scriptclassInstance) $scriptclassInstance } -argumentlist $newInstance
+            $deserializedInstance = receive-job $job
+            { $deserializedInstance.TestMethod() } | Should Throw
+        }
+
+        It "Returns the same value using instance state as a non-deserialized class without an exception when a ScriptClass method of a deserialized class is invoked with invoke-method notation" {
+            ScriptClass DeserializedSuccess {
+                $state = $null
+                function __initialize($state) {
+                    $this.state = $state
+                }
+                function GetClassState {
+                    $this.state
+                }
+            }
+
+            $stateValue = 159
+            $newInstance = new-so DeserializedSuccess $stateValue
+            $newInstance |=> GetClassState | Should Be $stateValue
+            $newInstance.GetClassState() | Should Be $stateValue
+
+            $job = start-job { param($scriptclassInstance) $scriptclassInstance } -argumentlist $newInstance
+            $deserializedInstance = receive-job $job -wait
+            { $deserializedInstance.GetClassState() } | Should Throw
+            $deserializedInstance |=> GetClassState | Should Be $stateValue
+        }
+
+        It "Restores . method invocation after a method is invoked with invoke-method notation once" {
+            ScriptClass DeserializedRestore {
+                $state = $null
+                function __initialize($state) {
+                    $this.state = $state
+                }
+                function GetClassState {
+                    $this.state
+                }
+            }
+
+            $stateValue = 157
+            $newInstance = new-so DeserializedRestore $stateValue
+            $newInstance |=> GetClassState | Should Be $stateValue
+            $newInstance.GetClassState() | Should Be $stateValue
+
+            $job = start-job { param($scriptclassInstance) $scriptclassInstance } -argumentlist $newInstance
+            $deserializedInstance = receive-job $job -wait
+            { $deserializedInstance.GetClassState() } | Should Throw
+            $deserializedInstance |=> GetClassState | Should Be $stateValue
+            $deserializedInstance.GetClassState() | Should Be $stateValue
+        }
+    }
+}
 

--- a/src/scriptclass.tests.ps1
+++ b/src/scriptclass.tests.ps1
@@ -142,9 +142,9 @@ Describe "The class definition interface" {
             $newInstance.scriptclass.scriptclass | Should BeExactly $null
         }
 
-        It "has a 'scriptclass' member that has exactly six noteproperty properties and one scriptproperty property" {
+        It "has a 'scriptclass' member that has exactly five noteproperty properties and one scriptproperty property" {
             $newInstance = new-scriptobject ClassClass53
-            ($newInstance.scriptclass | gm -membertype noteproperty).count | Should BeExactly 6
+            ($newInstance.scriptclass | gm -membertype noteproperty).count | Should BeExactly 5
             ($newInstance.scriptclass | gm -membertype scriptproperty) -is [Microsoft.PowerShell.Commands.MemberDefinition] | Should BeExactly $true
         }
 
@@ -667,13 +667,6 @@ Describe 'The $:: collection' {
 
         It "should return a class object that has a pstypedata property" {
             $::.ClassClass60.pstypedata | Should Not Be $null
-        }
-
-        It "should return a class object that has a ClassScriptBlock member of its scriptclass by default" {
-            add-scriptclass ClassClass62 { 62 }
-            $classType = $::.ClassClass62.pstypedata
-            $invokeResult = invoke-command -scriptblock $classType.members.ScriptClass.value.ClassScriptBlock
-            $invokeResult | Should BeExactly 62
         }
 
         It "should return a class object that has a $null scriptclass property" {


### PR DESCRIPTION
Fixes a number of serialization issues:
* Objects serialized and deserialized in the context of a PowerShell job (e.g. through `start-job`) were non-functional after deserialization. Fixed for method invocations through `|=>`, but still an issue for members that use `strict-val` because those members get deserialized as `noteproperty` rather than `scriptproperty`.
* Method script blocks were being serialized with the object. This was fixed by storing the methods in the class table rather than in the object.
* A few other minor fixes were added