### PR TITLE
Fix strict-val regression on pwsh 7.3.1 due to type to string ambiguity

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,15 +16,15 @@ jobs:
   strategy:
     matrix:
       PowerShellDesktop:
-        VM_IMAGE: 'windows-2019'
+        VM_IMAGE: 'windows-latest'
         OS_PLATFORM: 'windows'
         USE_POWERSHELL_CORE: false
       PowerShellCoreWindows:
-        VM_IMAGE: 'windows-2019'
+        VM_IMAGE: 'windows-latest'
         OS_PLATFORM: 'windows'
         USE_POWERSHELL_CORE: true
       PowerShellCoreUbuntu:
-        VM_IMAGE: 'ubuntu-16.04'
+        VM_IMAGE: 'ubuntu-latest'
         OS_PLATFORM: 'ubuntu'
         USE_POWERSHELL_CORE: true
   pool:

--- a/build/configure-tools.ps1
+++ b/build/configure-tools.ps1
@@ -31,6 +31,21 @@ if ( ! ( test-path $destinationPath ) ) {
     new-directory -name $destinationPath | out-null
 }
 
+# Make sure we're running the latest version of powershellget
+$minimumPowerShellGetVersion = [Version]::new('2.2.5')
+
+write-verbose "Checking for required version of PowerShellGet module '$minimumPowerShellGetVersion'"
+$latestPowerShellGetVersion = (get-module -listavailable PowerShellGet | sort-object version | select-object -last 1).Version
+write-verbose "Found latest version of PowerShellGet '$latestPowerShellGetVersion'"
+
+$meetsPowerShellGetRequirement = $latestPowerShellGetVersion -and $latestPowerShellGetVersion -ge $minimumPowerShellGetVersion
+
+if ( ! $meetsPowerShellGetRequirement ) {
+    # Don't bother using Update-Module since on Windows there is a "built-in" version that can't be updated with "Update-Module". :)
+    write-verbose "Installing new version of PowerShellGet to meet minimum version requirement"
+    Install-Package -scope CurrentUser -minimumVersion $minimumPowerShellGetVersion PowerShellGet -allowclobber -force | out-null
+}
+
 if ( $PSVersionTable.PSEdition -eq 'Desktop' ) {
     $nugetPath = join-path $destinationPath nuget.exe
 
@@ -74,7 +89,7 @@ if ( $PSVersionTable.PSEdition -eq 'Desktop' ) {
         write-verbose "Tool configuration validated successfully, no action necessary."
     }
 } else {
-    write-verbose "Not running on Windows, explicitly checking for required 'dotnet' tool for .net runtime..."
+    write-verbose "Not running on Windows PowerShell, explicitly checking for required 'dotnet' tool for .net runtime..."
 
     $dotNetToolPath = (get-command dotnet -erroraction ignore) -ne $null
 
@@ -140,7 +155,7 @@ if ( $PSVersionTable.PSEdition -eq 'Desktop' ) {
 
         # Installs runtime and SDK
         write-verbose 'Installing new .net version...'
-        (& $dotNetInstallerPath $versionArgument $minimumVersionString) | write-verbose
+        (invoke-expression "$dotNetInstallerPath $versionArgument $minimumVersionString | out-null") | out-null
 
         $dotNetToolFinalVerification = (get-command dotnet -erroraction ignore) -ne $null
 
@@ -153,14 +168,19 @@ if ( $PSVersionTable.PSEdition -eq 'Desktop' ) {
     } else {
         $actionRequired = $false
     }
+}
 
-    # Pester is present on the default Windows installation, but not for Linux
-    # TODO: May make sense to update to a specific version on both platforms.
-    if ( ! ( get-command invoke-pester -erroraction ignore ) ) {
-        $actionRequired = $true
-        write-verbose "Test tool 'pester' not found, installing the Pester Module..."
-        install-module -scope currentuser Pester -verbose
-    }
+
+$requiredPesterVersion = '4.8.1'
+write-verbose "Checking for required version of 'Pester' version '$requiredPesterVersion'"
+$pesterModule = import-module Pester -RequiredVersion $requiredPesterVersion -passthru -erroraction ignore
+if ( ! $pesterModule ) {
+    # Need to use skippublishercheck because on Windows there is already a signed version installed.
+    write-verbose "Test tool 'Pester' with required version '$requiredPesterVersion' not found, installing the required version of the Pester Module..."
+    install-module -scope currentuser Pester -RequiredVersion $requiredPesterVersion -AllowClobber -force -skippublishercheck -Verbose
+    import-module Pester -RequiredVersion $requiredPesterVersion | out-null
+} else {
+    write-verbose "Required version of Pester found, no update needed."
 }
 
 

--- a/scriptclass.nuspec
+++ b/scriptclass.nuspec
@@ -10,7 +10,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Usability enhancements for core PowerShell capabilities</description>
     <releaseNotes>Initial development</releaseNotes>
-    <copyright>Copyright 2019</copyright>
+    <copyright>Copyright 2023</copyright>
     <tags>class object ScriptClass PSModule</tags>
   </metadata>
   <files>

--- a/scriptclass.psd1
+++ b/scriptclass.psd1
@@ -17,7 +17,7 @@
 RootModule = 'scriptclass.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.20.2'
+ModuleVersion = '0.20.3'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -32,7 +32,7 @@ Author = 'Adam Edwards'
 CompanyName = 'Modulus Group'
 
 # Copyright statement for this module
-Copyright = '(c) 2020 Adam Edwards.'
+Copyright = '(c) 2023 Adam Edwards.'
 
 # Description of the functionality provided by this module
 Description = "Class definition extensions for PowerShell's object-based type system"
@@ -160,15 +160,22 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-# ScriptClass 0.20.2 Release Notes
+# ScriptClass 0.20.3 Release Notes
 
-Minor update for module icon due to change in default branch name to main.
+Minor update to fix blocking regression on PowerShell 7.3.1
 
 ## New features
 
+None.
+
 ## Breaking changes
 
+None.
+
 ## Fixed defects
+
+    * Regression on PowerShell 7.3.1 due to ambiguous type name string representation for types such as [ordered]@{} used with strict-val: https://github.com/adamedx/scriptclass/issues/36
+    * Minor issue with undefined variable accessed by error message when strict-val is used incorrectly: https://github.com/adamedx/scriptclass/issues/37
 
 '@
 

--- a/src/cmdlet/Add-MockInScriptClassScope.tests.ps1
+++ b/src/cmdlet/Add-MockInScriptClassScope.tests.ps1
@@ -41,8 +41,8 @@ Describe "AddMockInScriptClassScope cmdlet" {
                 Get-Event
             }
 
-            function GetDscData {
-                Get-DscResource
+            function GetHostData {
+                Get-Host
             }
         }
 
@@ -92,11 +92,11 @@ Describe "AddMockInScriptClassScope cmdlet" {
         }
 
         It 'Should throw an exception if the mock scriptblock attempts to access a variable defined in the scope that called the cmdlet' {
-            $dscData = 9
-            Add-MockInScriptClassScope CommandClass get-dscresource { $dscData }
+            $hostData = 9
+            Add-MockInScriptClassScope CommandClass get-host { $hostData }
             $instance = new-so CommandClass
 
-            { $instance |=> GetDscData } | Should Throw
+            { $instance |=> GetHostData } | Should Throw
         }
     }
 }

--- a/src/scriptobject/common/NativeObjectBuilder.ps1
+++ b/src/scriptobject/common/NativeObjectBuilder.ps1
@@ -86,7 +86,12 @@ class NativeObjectBuilder {
 
         if ( $type -or $isConstant ) {
             $typeCoercion = if ( $type ) {
-                "[$type]"
+                # We *MUST* use the FullName property here to avoid short type name collisions or other
+                # non-determinism stemming from the fact that ToString() for a given type is not required to
+                # return any valid type name (short, full, or anything else) -- FullName is required to do so however.
+                # An example is the type for [ordered]@{} which for an unknown reason resolves to the string "ordered"
+                # in some versions of PowerShell which is not a type.
+                "[$($type.FullName)]"
             } else {
                 ''
             }


### PR DESCRIPTION
### Description

An expression like `strict-val ([ordered]@{}).GetType() $null` would generate an exception sometimes on PowerShell 7.3.1.

### Dependency changes

None.

### Implementation notes

The `strict-val` feature used a type name converted to a string to implement type coercion and / or type checking. To do this, it took a user-specified instance of an actual dot net type and converted it to a string to create an expression that would perform the check / coercion. However, when the type is converted to string it was simply interpolated within a string as in `"$type"`, and that does not guarantee that the type's fully qualified name, or any valid name at all, is generated -- simply some string is emitted. On PowerShell 7.3.1, this could be reproduced by providing an ordered hash table type, i.e. the type of `[ordered]@{}` to `strict-val`, and this would generate the error captured in one of the code defects linked to this description.

### Linked issues

#36 #37 

### Checklist

- [x] New test coverage was added for the new functionality
- [x] All project tests pass successfully

